### PR TITLE
[minor] make rent a ship link point to home

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -10,7 +10,7 @@
     <% if user_signed_in? %>
 
       <!-- Links when logged in -->
-      <%= link_to "Rent a ship", ships_path, class: "navbar-wagon-item navbar-wagon-link" %>
+      <%= link_to "Rent a ship", root_path, class: "navbar-wagon-item navbar-wagon-link" %>
       <%= link_to "My Bookings", bookings_path, class: "navbar-wagon-item navbar-wagon-link" %>
       <%= link_to "Messages", "#", class: "navbar-wagon-item navbar-wagon-link" %>
 


### PR DESCRIPTION
link "rent a ship" in navbar point to root_path instead of ships_path (as it's not implemented yet)